### PR TITLE
Pass query to vendor/product-categories request

### DIFF
--- a/src/hooks/api/categories.tsx
+++ b/src/hooks/api/categories.tsx
@@ -59,6 +59,7 @@ export const useProductCategories = (
     queryFn: () =>
       fetchQuery('/vendor/product-categories', {
         method: 'GET',
+        query: query as Record<string, string>,
       }),
     ...options,
   });


### PR DESCRIPTION
Without passing query to the product-categories fetch, doing things like constructing the hierarchical tree (include_descendats_tree = true and parent_category_id = null) is not possible.

Mercur's backend also doesn't include the original Query validator for this route. This pull request should be merged in the backend for this not to fail. Otherwise, the validator won't pass successfully, because it won't now about these params: https://github.com/mercurjs/mercur/pull/171 