### PR TITLE
chore(MM2-1999): Bring back the "Add" button

### DIFF
--- a/src/hooks/api/campaigns.tsx
+++ b/src/hooks/api/campaigns.tsx
@@ -29,7 +29,7 @@ export const useCampaign = (
   >
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: campaignsQueryKeys.detail(id),
+    queryKey: campaignsQueryKeys.detail(id, query),
     queryFn: async () =>
       fetchQuery(`/vendor/campaigns/${id}`, {
         method: "GET",
@@ -159,7 +159,11 @@ export const useAddOrRemoveCampaignPromotions = (
   >
 ) => {
   return useMutation({
-    mutationFn: (payload) => sdk.admin.campaign.batchPromotions(id, payload),
+    mutationFn: (payload) =>
+      fetchQuery(`/vendor/campaigns/${id}/promotions`, {
+        method: "POST",
+        body: payload,
+      }),
     onSuccess: (data, variables, context) => {
       queryClient.invalidateQueries({
         queryKey: campaignsQueryKeys.details(),

--- a/src/routes/campaigns/campaign-detail/components/campaign-promotion-section/campaign-promotion-section.tsx
+++ b/src/routes/campaigns/campaign-detail/components/campaign-promotion-section/campaign-promotion-section.tsx
@@ -1,9 +1,10 @@
 import { PencilSquare, Trash } from "@medusajs/icons"
 import { AdminCampaign, AdminPromotion } from "@medusajs/types"
-import { Checkbox, Container, Heading, usePrompt } from "@medusajs/ui"
+import { Button, Checkbox, Container, Heading, usePrompt } from "@medusajs/ui"
 import { RowSelectionState, createColumnHelper } from "@tanstack/react-table"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
 
 import { ActionMenu } from "../../../../../components/common/action-menu"
 import { _DataTable } from "../../../../../components/table/data-table"
@@ -96,11 +97,11 @@ export const CampaignPromotionSection = ({
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
         <Heading level="h2">{t("promotions.domain")}</Heading>
-        {/* <Link to={`/campaigns/${campaign.id}/add-promotions`}>
+        <Link to={`/campaigns/${campaign.id}/add-promotions`}>
           <Button variant="secondary" size="small">
             {t("general.add")}
           </Button>
-        </Link> */}
+        </Link>
       </div>
 
       <_DataTable

--- a/src/routes/campaigns/campaign-detail/loader.ts
+++ b/src/routes/campaigns/campaign-detail/loader.ts
@@ -6,7 +6,7 @@ import { queryClient } from "../../../lib/query-client"
 import { CAMPAIGN_DETAIL_FIELDS } from "./constants"
 
 const campaignDetailQuery = (id: string) => ({
-  queryKey: campaignsQueryKeys.detail(id),
+  queryKey: campaignsQueryKeys.detail(id, { fields: CAMPAIGN_DETAIL_FIELDS }),
   queryFn: async () =>
     fetchQuery(`/vendor/campaigns/${id}`, {
       method: "GET",


### PR DESCRIPTION
- Unhide the 'Add' button.
- Update the useAddOrRemoveCampaignPromotions hook to use the newly created endpoint (from mercurjs/mercur#448).
- Fix the 'Remove' promotion button in campaigns (it wasn’t working before these changes).